### PR TITLE
Create basic K8s Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,14 @@ Unfortunately, we don't have any benchmarks for this model yet. If you have one,
 
 ## Roadmap and contributing
 
-We're working on adding more features to LlamaGPT. You can see the roadmap [here](https://github.com/getumbrel/llama-gpt/issues/8#issuecomment-1681321145). The highest priorities are:
+We're looking to add more features to LlamaGPT. You can see the roadmap [here](https://github.com/getumbrel/llama-gpt/issues/8#issuecomment-1681321145). The highest priorities are:
 
 - Add CUDA and Metal support.
 - Moving the model out of the Docker image and into a separate volume.
-- Updating the front-end to show model download progress, and allow users to switch between models.
+- Updating the front-end to show model download progress, and to allow users to switch between models.
 - Making it easy to run custom models.
 
-If you're a developer looking to help but not sure where to begin, check out [these issues](https://github.com/getumbrel/llama-gpt/labels/good%20first%20issue) that have specifically been marked as being friendly to new contributors.
-
-If you're looking for a bigger challenge, before opening a pull request please create an issue to get feedback, discuss the best way to tackle the challenge, and to ensure that there's no duplication of work.
+If you're a developer who'd like to help with any of these, please open an issue to discuss the best way to tackle the challenge. If you're looking to help but not sure where to begin, check out [these issues](https://github.com/getumbrel/llama-gpt/labels/good%20first%20issue) that have specifically been marked as being friendly to new contributors.
 
 ## Acknowledgements
 

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- llama-gpt-api-deployment.yaml
+- llama-gpt-api-service.yaml
+- llama-gpt-ui-deployment.yaml
+- llama-gpt-ui-service.yaml
+
+# patches:
+# - 
+
+configMapGenerator:
+- name: llama-gpt
+  literals:
+  - DEFAULT_MODEL=/models/llama-2-7b-chat.bin
+  - OPENAI_API_HOST=http://llama-gpt-api:8000
+  - OPEN_API_KEY=sk-XXXXXXXXXXXXXXXXXXXX
+  - WAIT_HOSTS=llama-gpt-api:8000
+  - WAIT_TIMEOUT="600"

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -13,8 +13,8 @@ resources:
 configMapGenerator:
 - name: llama-gpt
   literals:
-  - DEFAULT_MODEL=/models/llama-2-7b-chat.bin
-  - OPENAI_API_HOST=http://llama-gpt-api:8000
-  - OPEN_API_KEY=sk-XXXXXXXXXXXXXXXXXXXX
-  - WAIT_HOSTS=llama-gpt-api:8000
+  - DEFAULT_MODEL="/models/llama-2-7b-chat.bin"
+  - OPENAI_API_HOST="http://llama-gpt-api:8000"
+  - OPENAI_API_KEY="sk-XXXXXXXXXXXXXXXXXXXX"
+  - WAIT_HOSTS="llama-gpt-api:8000"
   - WAIT_TIMEOUT="600"

--- a/deploy/kubernetes/llama-gpt-api-deployment.yaml
+++ b/deploy/kubernetes/llama-gpt-api-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service: llama-gpt-api
+  name: llama-gpt-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: llama-gpt-api
+  template:
+    metadata:
+      labels:
+        service: llama-gpt-api
+    spec:
+      containers:
+        - name: llama-gpt-api
+          image: ghcr.io/getumbrel/llama-gpt-api:1.0.1
+          env:
+            - name: MODEL
+              valueFrom: 
+                configMapKeyRef:
+                  name: llama-gpt
+                  key: DEFAULT_MODEL
+          resources:
+            requests:
+              memory: 5Gi
+      restartPolicy: Always

--- a/deploy/kubernetes/llama-gpt-api-service.yaml
+++ b/deploy/kubernetes/llama-gpt-api-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: llama-gpt-api
+  name: llama-gpt-api
+spec:
+  ports:
+    - name: api
+      port: 8000
+      targetPort: 8000
+  selector:
+    service: llama-gpt-api
+status:
+  loadBalancer: {}

--- a/deploy/kubernetes/llama-gpt-ui-deployment.yaml
+++ b/deploy/kubernetes/llama-gpt-ui-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service: llama-gpt-ui
+  name: llama-gpt-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: llama-gpt-ui
+  template:
+    metadata:
+      labels:
+        service: llama-gpt-ui
+    spec:
+      containers:
+        - name: llama-gpt-ui
+          image: ghcr.io/getumbrel/llama-gpt-ui:latest
+          envFrom:
+          - configMapRef:
+              name: llama-gpt
+          ports:
+            - containerPort: 3000
+          resources: {}
+      restartPolicy: Always

--- a/deploy/kubernetes/llama-gpt-ui-service.yaml
+++ b/deploy/kubernetes/llama-gpt-ui-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: llama-gpt-ui
+  name: llama-gpt-ui
+spec:
+  ports:
+    - name: ui
+      port: 3000
+      targetPort: 3000
+  selector:
+    service: llama-gpt-ui
+  type: LoadBalancer
+status:
+  loadBalancer: {}

--- a/deploy/kubernetes/llama-gpt-ui-service.yaml
+++ b/deploy/kubernetes/llama-gpt-ui-service.yaml
@@ -11,6 +11,6 @@ spec:
       targetPort: 3000
   selector:
     service: llama-gpt-ui
-  type: LoadBalancer
+  type: ClusterIP
 status:
   loadBalancer: {}


### PR DESCRIPTION
Ok, we have a very basic config here that moves the env stuff into a configmap. 

To deploy to Kubernetes first create a namespace:
```bash
kubectl create ns llama
```

Then apply the manifests under the `/deploy/kubernetes` directory with
```bash
kubectl apply -k deploy/kubernetes/. -n llama
```

![Screenshot 2023-08-17 at 3 18 16 PM](https://github.com/getumbrel/llama-gpt/assets/3849900/802a3114-f808-4b9b-95de-f2f5f9bf7f8c)

![Screenshot 2023-08-17 at 3 19 25 PM](https://github.com/getumbrel/llama-gpt/assets/3849900/bd0ad6e5-d8c2-4991-ac51-de4d97d692e5)

Expose your service however you would normally do that. 