### PR TITLE
doc: add benchmark for 70B model on M2 Max 96GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ Feel free to add your own benchmarks to this table by opening a pull request.
 
 ### Meta Llama 2 70B Chat (GGML q4_0)
 
-Unfortunately, we don't have any benchmarks for this model yet. If you have one, please open a pull request to add it to this table.
+| Device                        | Generation speed |
+| ----------------------------- | ---------------- |
+| M2 Max MacBook Pro (96GB RAM) | 0.69 tokens/sec  |
+
 
 ## Roadmap and contributing
 


### PR DESCRIPTION
Here are 3 sample results of the same evaluation:

HW Specification:
  Model Name:	MacBook Pro
  Model Identifier:	Mac14,5
  Model Number:	Z17J002KXZE/A
  Chip:	Apple M2 Max
  Total Number of Cores:	12 (8 performance and 4 efficiency)
  Memory:	96 GB
  System Firmware Version:	8422.121.1
  OS Loader Version:	8422.121.1

llama_print_timings:        load time = 28606.21 ms
llama_print_timings:      sample time =    15.31 ms /    31 runs   (    0.49 ms per token,  2024.56 tokens per second)
llama_print_timings: prompt eval time = 10514.60 ms /    11 tokens (  955.87 ms per token,     1.05 tokens per second)
llama_print_timings:        eval time = 49937.32 ms /    30 runs   ( 1664.58 ms per token,     0.60 tokens per second)
llama_print_timings:       total time = 60533.22 ms

llama_print_timings:        load time = 28606.21 ms
llama_print_timings:      sample time =    16.67 ms /    36 runs   (    0.46 ms per token,  2159.44 tokens per second)
llama_print_timings: prompt eval time =     0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_print_timings:        eval time = 54622.37 ms /    36 runs   ( 1517.29 ms per token,     0.66 tokens per second)
llama_print_timings:       total time = 54698.42 ms

llama_print_timings:        load time = 28606.21 ms
llama_print_timings:      sample time =    16.65 ms /    36 runs   (    0.46 ms per token,  2162.42 tokens per second)
llama_print_timings: prompt eval time =     0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_print_timings:        eval time = 52103.84 ms /    36 runs   ( 1447.33 ms per token,     0.69 tokens per second)
llama_print_timings:       total time = 52180.40 ms