### PR TITLE
fix: failed to solve process

### DIFF
--- a/api/13B.Dockerfile
+++ b/api/13B.Dockerfile
@@ -14,7 +14,7 @@ ARG MODEL_DOWNLOAD_URL
 RUN apt-get update -y && \
     apt-get install --yes curl && \
     mkdir -p /models && \
-    curl -L -o /models/${MODEL_FILE} ${MODEL_DOWNLOAD_URL}
+    curl -L --tlsv1.2 -o /models/${MODEL_FILE} ${MODEL_DOWNLOAD_URL}
 
 WORKDIR /app
 

--- a/api/70B.Dockerfile
+++ b/api/70B.Dockerfile
@@ -14,7 +14,7 @@ ARG MODEL_DOWNLOAD_URL
 RUN apt-get update -y && \
     apt-get install --yes curl && \
     mkdir -p /models && \
-    curl -L -o /models/${MODEL_FILE} ${MODEL_DOWNLOAD_URL}
+    curl -L --tlsv1.2 -o /models/${MODEL_FILE} ${MODEL_DOWNLOAD_URL}
 
 WORKDIR /app
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -14,7 +14,7 @@ ARG MODEL_DOWNLOAD_URL
 RUN apt-get update -y && \
     apt-get install --yes curl && \
     mkdir -p /models && \
-    curl -L -o /models/${MODEL_FILE} ${MODEL_DOWNLOAD_URL}
+    curl -L --tlsv1.2 -o /models/${MODEL_FILE} ${MODEL_DOWNLOAD_URL}
 
 WORKDIR /app
 


### PR DESCRIPTION
# The problem

Log: 

```bash
 => ERROR [2/4] RUN apt-get update -y &&     apt-get install --yes curl &&     mkdir -p /models &&     curl -L -o   19.0s
------
 > [2/4] RUN apt-get update -y &&     apt-get install --yes curl &&     mkdir -p /models &&     curl -L -o /models/llama-2-7b-chat.bin https://huggingface.co/TheBloke/Nous-Hermes-Llama-2-7B-GGML/resolve/main/nous-hermes-llama-2-7b.ggmlv3.q4_0.bin:
.....
#0 2.274 Processing triggers for libc-bin (2.31-13+deb11u6) ...
#0 2.339   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#0 2.339                                  Dload  Upload   Total   Spent    Left  Speed
100  1262  100  1262    0     0   4622      0 --:--:-- --:--:-- --:--:--  4622
 24 3616M   24  886M    0     0  54.1M      0  0:01:06  0:00:16  0:00:50 60.8M
#0 18.70 curl: (56) OpenSSL SSL_read: Connection reset by peer, errno 104
------
failed to solve: process "/bin/sh -c apt-get update -y &&     apt-get install --yes curl &&     mkdir -p /models &&     curl -L -o /models/${MODEL_FILE} ${MODEL_DOWNLOAD_URL}" did not complete successfully: exit code: 56
```

# Why

I am using Macbook 2021 Pro

Incompatible SSL/TLS Protocols: The client (curl) and server might be using incompatible versions of the SSL/TLS protocol. For example, if the server only supports TLS 1.2 and the client is trying to use TLS 1.3, the handshake can fail.

# Solving

Specify TLS Version:
Explicitly specify a specific TLS version using the --tlsv1.2 flag with the curl command.

Like this:

```bash
RUN curl -L --tlsv1.2 -o /models/${MODEL_FILE} ${MODEL_DOWNLOAD_URL}
```
