### PR TITLE
Add Metal (GPU) support for M1/M2 Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,28 @@ Running LlamaGPT on an [umbrelOS](https://umbrel.com) home server is one click. 
 
 ---
 
-### Install LlamaGPT anywhere else with Docker
+### Install LlamaGPT on M1/M2 Mac
+
+Make sure your have Docker and Xcode installed.
+
+Then, clone this repo and `cd` into it:
+
+```
+git clone https://github.com/getumbrel/llama-gpt.git
+cd llama-gpt
+```
+
+Run LlamaGPT with the following command:
+
+```
+./run-mac.sh --model 7b
+```
+
+To run 13B or 70B models, replace `7b` with `13b` or `70b` respectively.
+
+To stop LlamaGPT, do `Ctrl + C` in Terminal.
+
+### Install LlamaGPT anywhere else with Docker (CPU only)
 
 You can run LlamaGPT on any x86 or arm64 system. Make sure you have Docker installed.
 
@@ -113,25 +134,28 @@ Feel free to add your own benchmarks to this table by opening a pull request.
 
 #### Nous Hermes Llama 2 7B (GGML q4_0)
 
-| Device                           | Generation speed |
-| -------------------------------- | ---------------- |
-| M1 Max MacBook Pro (10 64GB RAM) | 8.2 tokens/sec   |
-| Umbrel Home (16GB RAM)           | 2.7 tokens/sec   |
-| Raspberry Pi 4 (8GB RAM)         | 0.9 tokens/sec   |
+| Device                                            | Generation speed |
+| ------------------------------------------------- | ---------------- |
+| M1 Max MacBook Pro (64GB RAM) with `./run-mac.sh` | 54 tokens/sec    |
+| M1 Max MacBook Pro (64GB RAM) with Docker         | 8.2 tokens/sec   |
+| Umbrel Home (16GB RAM)                            | 2.7 tokens/sec   |
+| Raspberry Pi 4 (8GB RAM)                          | 0.9 tokens/sec   |
 
 #### Nous Hermes Llama 2 13B (GGML q4_0)
 
-| Device                        | Generation speed |
-| ----------------------------- | ---------------- |
-| M1 Max MacBook Pro (64GB RAM) | 3.7 tokens/sec   |
-| Umbrel Home (16GB RAM)        | 1.5 tokens/sec   |
+| Device                                            | Generation speed |
+| ------------------------------------------------- | ---------------- |
+| M1 Max MacBook Pro (64GB RAM) with `./run-mac.sh` | 20 tokens/sec    |
+| M1 Max MacBook Pro (64GB RAM) with Docker         | 3.7 tokens/sec   |
+| Umbrel Home (16GB RAM)                            | 1.5 tokens/sec   |
 
 #### Meta Llama 2 70B Chat (GGML q4_0)
 
-| Device                              | Generation speed |
-| ----------------------------------- | ---------------- |
-| M2 Max MacBook Pro (96GB RAM)       | 0.69 tokens/sec  |
-| GCP e2-standard-16 vCPU (64 GB RAM) | 1.75 tokens/sec  |
+| Device                                            | Generation speed |
+| ------------------------------------------------- | ---------------- |
+| M1 Max MacBook Pro (64GB RAM) with `./run-mac.sh` | 4.8 tokens/sec   |
+| GCP e2-standard-16 vCPU (64 GB RAM)               | 1.75 tokens/sec  |
+| M2 Max MacBook Pro (96GB RAM) with Docker         | 0.69 tokens/sec  |
 
 ## Roadmap and contributing
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ Feel free to add your own benchmarks to this table by opening a pull request.
 We're looking to add more features to LlamaGPT. You can see the roadmap [here](https://github.com/getumbrel/llama-gpt/issues/8#issuecomment-1681321145). The highest priorities are:
 
 - [x] Moving the model out of the Docker image and into a separate volume.
-- [ ] Add CUDA and Metal support (work in progress).
+- [x] Add Metal support for M1/M2 Macs.
+- [ ] Add CUDA support for NVIDIA GPUs (work in progress).
 - [ ] Add ability to load custom models.
 - [ ] Allow users to switch between models.
 - [ ] Making it easy to run custom models.

--- a/docker-compose-mac.yml
+++ b/docker-compose-mac.yml
@@ -1,0 +1,14 @@
+version: '3.6'
+
+services:
+  llama-gpt-ui-mac:
+    build:
+      context: ./ui
+      dockerfile: no-wait.Dockerfile
+    ports:
+      - 3000:3000
+    restart: on-failure
+    environment:
+      - 'OPENAI_API_KEY=sk-XXXXXXXXXXXXXXXXXXXX'
+      - 'OPENAI_API_HOST=http://host.docker.internal:3001'
+      - 'DEFAULT_MODEL=$MODEL'

--- a/run-mac.sh
+++ b/run-mac.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+set -e
+
+source_shell_rc() {
+    # Source .zshrc or .bashrc
+    if [ -f ~/.zshrc ]; then
+        source ~/.zshrc
+    elif [ -f ~/.bashrc ]; then
+        source ~/.bashrc
+    else
+        echo "No .bashrc or .zshrc file found."
+    fi
+}
+
+install_conda() {
+    # Download Miniforge3
+    curl -L -o /tmp/Miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
+    bash /tmp/Miniforge3.sh
+    source_shell_rc
+}
+
+source_shell_rc
+
+# Check if the platform is MacOS and the architecture is arm64
+if [[ "$(uname)" != "Darwin" ]] || [[ "$(uname -m)" != "arm64" ]]; then
+    echo "This script is intended to be run on MacOS with M1/M2 chips. Exiting..."
+    exit 1
+fi
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+    echo "Docker is not installed. Exiting..."
+    exit 1
+fi
+
+# Check if python3 is installed
+if ! command -v python3 &> /dev/null; then
+    echo "Python3 is not installed. Exiting..."
+    exit 1
+fi
+
+# Check if Xcode is installed
+xcode_path=$(xcode-select -p 2>/dev/null)
+if [ -z "$xcode_path" ]; then
+    echo "Xcode is not installed. Installing (this may take a long time)..."
+    xcode-select --install
+else
+    echo "Xcode is installed at $xcode_path"
+fi
+
+# Check if conda is installed
+if ! command -v conda &> /dev/null; then
+    echo "Conda is not installed. Installing Miniforge3 which includes conda..."
+    install_conda
+else
+    echo "Conda is installed."
+    # TODO: Check if the conda version for MacOS that supports Metal GPU is installed
+    # conda_version=$(conda --version)
+    # if [[ $conda_version != *"Miniforge3"* ]]; then
+    #     echo "Conda version that supports Metal GPU is not installed. Installing..."
+    #     install_conda
+    # else
+    #     echo "Conda version that supports M1/M2 is installed."
+    # fi
+fi
+
+
+# Check if the conda environment 'llama-gpt' exists
+if conda env list | grep -q 'llama-gpt'; then
+    echo "Conda environment 'llama-gpt' already exists."
+else
+    echo "Creating a conda environment called 'llama-gpt'..."
+    conda create -n llama-gpt python=$(python3 --version | cut -d ' ' -f 2)
+fi
+
+# Check if the conda environment 'llama-gpt' is active
+if [[ "$(conda info --envs | grep '*' | awk '{print $1}')" != "llama-gpt" ]]; then
+    echo "Activating the conda environment 'llama-gpt'..."
+    conda activate llama-gpt
+else
+    echo "Conda environment 'llama-gpt' is already active."
+fi
+
+# Check if llama-cpp-python is already installed
+llama_cpp_python_installed=$(pip3 show llama-cpp-python)
+if [[ -z "$llama_cpp_python_installed" ]]; then
+    echo "llama-cpp-python is not installed. Installing..."
+    CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip3 install -U llama-cpp-python --no-cache-dir
+    pip3 install 'llama-cpp-python[server]'
+else
+    echo "llama-cpp-python is installed."
+    # Check if llama-cpp-python version is greater than 0.1.62
+    llama_cpp_python_version=$(echo "$llama_cpp_python_installed" | grep -i version | cut -d ' ' -f 2)
+    if [[ $(echo "$llama_cpp_python_version 0.1.62" | awk '{print ($1 > $2)}') -eq 1 ]]; then
+        echo "llama-cpp-python version is greater than 0.1.62. No need to install."
+    else
+        echo "Updating llama-cpp-python to the latest version..."
+        pip3 uninstall llama-cpp-python -y
+        CMAKE_ARGS="-DLLAMA_METAL=on" FORCE_CMAKE=1 pip3 install -U llama-cpp-python --no-cache-dir
+        pip3 install 'llama-cpp-python[server]'
+    fi
+fi
+
+# Parse command line arguments for --model
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --model) MODEL="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# If no model is passed, default to 7b model
+if [[ -z "$MODEL" ]]; then
+    echo "No model specified. Defaulting to 7b model."
+    MODEL="7b"
+fi
+
+# Set values for MODEL and MODEL_DOWNLOAD_URL based on the model passed
+case $MODEL in
+    7b) 
+        MODEL="./models/llama-2-7b-chat.bin"
+        MODEL_DOWNLOAD_URL="https://huggingface.co/TheBloke/Nous-Hermes-Llama-2-7B-GGML/resolve/main/nous-hermes-llama-2-7b.ggmlv3.q4_0.bin"
+        ;;
+    13b) 
+        MODEL="./models/llama-2-13b-chat.bin"
+        MODEL_DOWNLOAD_URL="https://huggingface.co/TheBloke/Nous-Hermes-Llama2-GGML/resolve/main/nous-hermes-llama2-13b.ggmlv3.q4_0.bin"
+        ;;
+    70b) 
+        MODEL="./models/llama-2-70b-chat.bin"
+        MODEL_DOWNLOAD_URL="https://huggingface.co/TheBloke/Llama-2-70B-Chat-GGML/resolve/main/llama-2-70b-chat.ggmlv3.q4_0.bin"
+        ;;
+    *) 
+        echo "Invalid model passed: $MODEL"; exit 1 
+        ;;
+esac
+
+# Check if the model file exists
+if [ ! -f $MODEL ]; then
+    echo "Model file not found. Downloading..."
+    # Download the model file
+    curl -L -o $MODEL $MODEL_DOWNLOAD_URL
+    if [ $? -ne 0 ]; then
+        echo "Download failed. Trying with TLS 1.2..."
+        curl -L --tlsv1.2 -o $MODEL $MODEL_DOWNLOAD_URL
+    fi
+else
+    echo "$MODEL model found."
+fi
+
+# Get the number of available CPU cores and subtract 2
+n_threads=$(($(sysctl -n hw.logicalcpu) - 2))
+
+# Define context window
+n_ctx=4096
+
+# Offload automatically to GPU
+n_gpu_layers=1
+
+# Define batch size
+n_batch=2096
+
+# Display configuration information
+echo "Initializing server with:"
+echo "Batch size: $n_batch"
+echo "Number of CPU threads: $n_threads"
+echo "Number of GPU layers: $n_gpu_layers"
+echo "Context window: $n_ctx"
+
+# Export MODEL as an environment variable
+export MODEL
+
+# Run docker-compose with the macOS yml file
+docker compose -f ./docker-compose-mac.yml up --remove-orphans --build &
+
+# Get the PID of the docker-compose command
+DOCKER_COMPOSE_PID=$!
+
+# Llama 2 70B's grouping factor is 8 compared to 7B and 13B's 1. Currently,
+# it's not possible to change this using --n_gqa with llama-cpp-python in
+# run.sh, so we expose it as an environment variable.
+# See: https://github.com/abetlen/llama-cpp-python/issues/528
+# and: https://github.com/facebookresearch/llama/issues/407
+if [[ $MODEL == "./models/llama-2-70b-chat.bin" ]]; then
+    export N_GQA=8
+fi
+
+# Run the server
+python3 -m llama_cpp.server  --n_ctx $n_ctx --n_threads $n_threads --n_gpu_layers $n_gpu_layers --n_batch $n_batch --model $MODEL --port 3001 &
+
+# Get the PID of the python3 command
+PYTHON_PID=$!
+
+# Define a function to stop docker-compose and the python3 command
+stop_commands() {
+    kill $DOCKER_COMPOSE_PID
+    kill $PYTHON_PID
+}
+
+# Set a trap to catch SIGINT and stop the commands
+trap stop_commands SIGINT
+
+# Wait for both commands to finish
+wait $DOCKER_COMPOSE_PID
+wait $PYTHON_PID
+
+

--- a/ui/no-wait.Dockerfile
+++ b/ui/no-wait.Dockerfile
@@ -1,0 +1,30 @@
+# ---- Base Node ----
+FROM node:19-alpine AS base
+WORKDIR /app
+COPY package*.json ./
+
+# ---- Dependencies ----
+FROM base AS dependencies
+RUN npm ci
+
+# ---- Build ----
+FROM dependencies AS build
+COPY . .
+RUN npm run build
+
+# ---- Production ----
+FROM node:19-alpine AS production
+WORKDIR /app
+COPY --from=dependencies /app/node_modules ./node_modules
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/public ./public
+COPY --from=build /app/package*.json ./
+COPY --from=build /app/next.config.js ./next.config.js
+COPY --from=build /app/next-i18next.config.js ./next-i18next.config.js
+
+# Expose the port the app will run on
+EXPOSE 3000
+
+# Start the application after the API is ready
+CMD npm start
+

--- a/ui/types/openai.ts
+++ b/ui/types/openai.ts
@@ -15,6 +15,9 @@ export enum OpenAIModelID {
   LLAMA_7B_CHAT_GGMLV3_Q4_0 = '/models/llama-2-7b-chat.bin',
   LLAMA_13B_CHAT_GGMLV3_Q4_0 = '/models/llama-2-13b-chat.bin',
   LLAMA_70B_CHAT_GGMLV3_Q4_0 = '/models/llama-2-70b-chat.bin',
+  LLAMA_7B_CHAT_GGMLV3_Q4_0_MAC = './models/llama-2-7b-chat.bin',
+  LLAMA_13B_CHAT_GGMLV3_Q4_0_MAC = './models/llama-2-13b-chat.bin',
+  LLAMA_70B_CHAT_GGMLV3_Q4_0_MAC = './models/llama-2-70b-chat.bin',
 }
 
 // in case the `DEFAULT_MODEL` environment variable is not set or set to an unsupported model
@@ -58,6 +61,24 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
     tokenLimit: 4000,
   },
   [OpenAIModelID.LLAMA_70B_CHAT_GGMLV3_Q4_0]: {
+    id: OpenAIModelID.LLAMA_70B_CHAT_GGMLV3_Q4_0,
+    name: 'Llama 2 70B',
+    maxLength: 12000,
+    tokenLimit: 4000,
+  },
+  [OpenAIModelID.LLAMA_7B_CHAT_GGMLV3_Q4_0_MAC]: {
+    id: OpenAIModelID.LLAMA_7B_CHAT_GGMLV3_Q4_0,
+    name: 'Llama 2 7B',
+    maxLength: 12000,
+    tokenLimit: 4000,
+  },
+  [OpenAIModelID.LLAMA_13B_CHAT_GGMLV3_Q4_0_MAC]: {
+    id: OpenAIModelID.LLAMA_13B_CHAT_GGMLV3_Q4_0,
+    name: 'Llama 2 13B',
+    maxLength: 12000,
+    tokenLimit: 4000,
+  },
+  [OpenAIModelID.LLAMA_70B_CHAT_GGMLV3_Q4_0_MAC]: {
     id: OpenAIModelID.LLAMA_70B_CHAT_GGMLV3_Q4_0,
     name: 'Llama 2 70B',
     maxLength: 12000,


### PR DESCRIPTION
This PR introduces Metal support for LlamaGPT when running on M1/M2 Macs. This is achieved by running the `llama-cpp-python` directly on the host, since Metal support via Docker isn't currently possible. Benchmarks on M1 Max have also been added to the readme.

Here's a demo of the 13B model on M1 Max MacBook Pro (64GB RAM):

https://github.com/getumbrel/llama-gpt/assets/10330103/1acb6544-8a6e-4343-98a1-fe32d96eb522

