### PR TITLE
Add CUDA support for Nvidia GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 <p align="center">
   <h1 align="center">LlamaGPT</h1>
   <p align="center">
-    A self-hosted, offline, ChatGPT-like chatbot, powered by Llama 2. 100% private, with no data leaving your device. New: Code Llama support!
+    A self-hosted, offline, ChatGPT-like chatbot, powered by Llama 2. 100% private, with no data leaving your device.
+    <br/>
+    <strong>New: Support for Code Llama models, and support for Nvidia GPUs.</strong>
+    <br />
     <br />
     <a href="https://umbrel.com"><strong>umbrel.com (we're hiring) »</strong></a>
     <br />
@@ -38,7 +41,7 @@
 3. [How to install](#how-to-install)
    - [On umbrelOS home server](#install-llamagpt-on-your-umbrelos-home-server)
    - [On M1/M2 Mac](#install-llamagpt-on-m1m2-mac)
-   - [Anywhere else with Docker (CPU only or with CUDA)](#install-llamagpt-anywhere-else-with-docker-cpu-only)
+   - [Anywhere else with Docker](#install-llamagpt-anywhere-else-with-docker)
    - [Kubernetes](#install-llamagpt-with-kubernetes)
 4. [OpenAI-compatible API](#openai-compatible-api)
 5. [Benchmarks](#benchmarks)
@@ -111,7 +114,7 @@ Run LlamaGPT with the following command:
 ./run.sh --model 7b
 ```
 
-Or if you have an NVIDIA GPU, you can run LlamaGPT with CUDA support for faster interference with:
+Or if you have an Nvidia GPU, you can run LlamaGPT with CUDA support using the `--with-model` flag, like:
 
 ```
 ./run.sh --model 7b --with-cuda

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p align="center">
     A self-hosted, offline, ChatGPT-like chatbot, powered by Llama 2. 100% private, with no data leaving your device.
     <br/>
-    <strong>New: Support for Code Llama models, and support for Nvidia GPUs.</strong>
+    <strong>New: Support for Code Llama models and Nvidia GPUs.</strong>
     <br />
     <br />
     <a href="https://umbrel.com"><strong>umbrel.com (we're hiring) »</strong></a>

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Run LlamaGPT with the following command:
 ./run-mac.sh --model 7b
 ```
 
-You can access LlamaGPT at `http://localhost:3000`.
+You can access LlamaGPT at http://localhost:3000.
 
-To run 13B or 70B chat models, replace `7b` with `13b` or `70b` respectively.
-To run 7B, 13B or 34B Code Llama models, replace `7b` with `code-7b`, `code-13b` or `code-34b` respectively.
+> To run 13B or 70B chat models, replace `7b` with `13b` or `70b` respectively.
+> To run 7B, 13B or 34B Code Llama models, replace `7b` with `code-7b`, `code-13b` or `code-34b` respectively.
 
 To stop LlamaGPT, do `Ctrl + C` in Terminal.
 
@@ -114,7 +114,7 @@ Run LlamaGPT with the following command:
 ./run.sh --model 7b
 ```
 
-Or if you have an Nvidia GPU, you can run LlamaGPT with CUDA support using the `--with-model` flag, like:
+Or if you have an Nvidia GPU, you can run LlamaGPT with CUDA support using the `--with-cuda` flag, like:
 
 ```
 ./run.sh --model 7b --with-cuda
@@ -122,8 +122,8 @@ Or if you have an Nvidia GPU, you can run LlamaGPT with CUDA support using the `
 
 You can access LlamaGPT at `http://localhost:3000`.
 
-To run 13B or 70B chat models, replace `7b` with `13b` or `70b` respectively.
-To run Code Llama 7B, 13B or 34B models, replace `7b` with `code-7b`, `code-13b` or `code-34b` respectively.
+> To run 13B or 70B chat models, replace `7b` with `13b` or `70b` respectively.
+> To run Code Llama 7B, 13B or 34B models, replace `7b` with `code-7b`, `code-13b` or `code-34b` respectively.
 
 To stop LlamaGPT, do `Ctrl + C` in Terminal.
 
@@ -139,7 +139,7 @@ To stop LlamaGPT, do `Ctrl + C` in Terminal.
 > llama-gpt-ui_1   | ready - started server on 0.0.0.0:3000, url: http://localhost:3000
 > ```
 >
-> You can then access LlamaGPT at `http://localhost:3000`.
+> You can then access LlamaGPT at http://localhost:3000.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ https://github.com/getumbrel/llama-gpt/assets/10330103/5d1a76b8-ed03-4a51-90bd-1
 
 Currently, LlamaGPT supports the following models. Support for running custom models is on the roadmap.
 
-| Model name                               | Model size | Model download size | RAM required |
-| ---------------------------------------- | ---------- | ------------------- | ------------ |
-| Nous Hermes Llama 2 7B Chat (GGML q4_0)  | 7B         | 3.79GB              | 6.29GB       |
-| Nous Hermes Llama 2 13B Chat (GGML q4_0) | 13B        | 7.32GB              | 9.82GB       |
-| Nous Hermes Llama 2 70B Chat (GGML q4_0) | 70B        | 38.87GB             | 41.37GB      |
-| Code Llama 7B Chat (GGUF Q4_K_M)         | 7B         | 4.24GB              | 6.74GB       |
-| Code Llama 13B Chat (GGUF Q4_K_M)        | 13B        | 8.06GB              | 10.56GB      |
-| Phind Code Llama 34B Chat (GGUF Q4_K_M)  | 34B        | 20.22GB             | 22.72GB      |
+| Model name                               | Model size | Model download size | Memory required |
+| ---------------------------------------- | ---------- | ------------------- | --------------- |
+| Nous Hermes Llama 2 7B Chat (GGML q4_0)  | 7B         | 3.79GB              | 6.29GB          |
+| Nous Hermes Llama 2 13B Chat (GGML q4_0) | 13B        | 7.32GB              | 9.82GB          |
+| Nous Hermes Llama 2 70B Chat (GGML q4_0) | 70B        | 38.87GB             | 41.37GB         |
+| Code Llama 7B Chat (GGUF Q4_K_M)         | 7B         | 4.24GB              | 6.74GB          |
+| Code Llama 13B Chat (GGUF Q4_K_M)        | 13B        | 8.06GB              | 10.56GB         |
+| Phind Code Llama 34B Chat (GGUF Q4_K_M)  | 34B        | 20.22GB             | 22.72GB         |
 
 ## How to install
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 3. [How to install](#how-to-install)
    - [On umbrelOS home server](#install-llamagpt-on-your-umbrelos-home-server)
    - [On M1/M2 Mac](#install-llamagpt-on-m1m2-mac)
-   - [Anywhere else with Docker (CPU only)](#install-llamagpt-anywhere-else-with-docker-cpu-only)
+   - [Anywhere else with Docker (CPU only or with CUDA)](#install-llamagpt-anywhere-else-with-docker-cpu-only)
    - [Kubernetes](#install-llamagpt-with-kubernetes)
 4. [OpenAI-compatible API](#openai-compatible-api)
 5. [Benchmarks](#benchmarks)
@@ -94,7 +94,7 @@ To run 7B, 13B or 34B Code Llama models, replace `7b` with `code-7b`, `code-13b`
 
 To stop LlamaGPT, do `Ctrl + C` in Terminal.
 
-### Install LlamaGPT anywhere else with Docker (CPU only)
+### Install LlamaGPT anywhere else with Docker
 
 You can run LlamaGPT on any x86 or arm64 system. Make sure you have Docker installed.
 
@@ -109,6 +109,12 @@ Run LlamaGPT with the following command:
 
 ```
 ./run.sh --model 7b
+```
+
+Or if you have an NVIDIA GPU, you can run LlamaGPT with CUDA support for faster interference with:
+
+```
+./run.sh --model 7b --with-cuda
 ```
 
 You can access LlamaGPT at `http://localhost:3000`.
@@ -216,7 +222,7 @@ We're looking to add more features to LlamaGPT. You can see the roadmap [here](h
 - [x] Moving the model out of the Docker image and into a separate volume.
 - [x] Add Metal support for M1/M2 Macs.
 - [x] Add support for Code Llama models.
-- [ ] Add CUDA support for NVIDIA GPUs (work in progress).
+- [x] Add CUDA support for NVIDIA GPUs.
 - [ ] Add ability to load custom models.
 - [ ] Allow users to switch between models.
 

--- a/cuda/ggml.Dockerfile
+++ b/cuda/ggml.Dockerfile
@@ -1,0 +1,27 @@
+ARG CUDA_IMAGE="12.1.1-devel-ubuntu22.04"
+FROM nvidia/cuda:${CUDA_IMAGE}
+
+# We need to set the host to 0.0.0.0 to allow outside access
+ENV HOST 0.0.0.0
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y git build-essential \
+    python3 python3-pip gcc wget \
+    ocl-icd-opencl-dev opencl-headers clinfo \
+    libclblast-dev libopenblas-dev \
+    && mkdir -p /etc/OpenCL/vendors && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+
+COPY . .
+
+# setting build related env vars
+ENV CUDA_DOCKER_ARCH=all
+ENV LLAMA_CUBLAS=1
+
+# Install depencencies
+RUN python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi uvicorn sse-starlette pydantic-settings
+
+# Install llama-cpp-python 0.1.78 which has GGML support (build with cuda)
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.78
+
+# Run the server
+CMD python3 -m llama_cpp.server

--- a/cuda/gguf.Dockerfile
+++ b/cuda/gguf.Dockerfile
@@ -21,7 +21,7 @@ ENV LLAMA_CUBLAS=1
 RUN python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi uvicorn sse-starlette pydantic-settings
 
 # Install llama-cpp-python 0.1.80 which has GGUF support (build with cuda)
-RUN FORCE_CMAKE=1 pip install llama-cpp-python==0.1.80
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.80
 
 # Run the server
 CMD python3 -m llama_cpp.server

--- a/cuda/gguf.Dockerfile
+++ b/cuda/gguf.Dockerfile
@@ -1,0 +1,27 @@
+ARG CUDA_IMAGE="12.1.1-devel-ubuntu22.04"
+FROM nvidia/cuda:${CUDA_IMAGE}
+
+# We need to set the host to 0.0.0.0 to allow outside access
+ENV HOST 0.0.0.0
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y git build-essential \
+    python3 python3-pip gcc wget \
+    ocl-icd-opencl-dev opencl-headers clinfo \
+    libclblast-dev libopenblas-dev \
+    && mkdir -p /etc/OpenCL/vendors && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+
+COPY . .
+
+# setting build related env vars
+ENV CUDA_DOCKER_ARCH=all
+ENV LLAMA_CUBLAS=1
+
+# Install depencencies
+RUN python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi uvicorn sse-starlette pydantic-settings
+
+# Install llama-cpp-python 0.1.80 which has GGUF support (build with cuda)
+RUN FORCE_CMAKE=1 pip install llama-cpp-python==0.1.80
+
+# Run the server
+CMD python3 -m llama_cpp.server

--- a/cuda/run.sh
+++ b/cuda/run.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+ # Check if the MODEL environment variable is set
+ if [ -z "$MODEL" ]
+ then
+     echo "Please set the MODEL_FILE environment variable"
+     exit 1
+ fi
+
+ # Check if the MODEL_DOWNLOAD_URL environment variable is set
+ if [ -z "$MODEL_DOWNLOAD_URL" ]
+ then
+     echo "Please set the MODEL_DOWNLOAD_URL environment variable"
+     exit 1
+ fi
+
+ # Check if the model file exists
+ if [ ! -f $MODEL ]; then
+     echo "Model file not found. Downloading..."
+     # Check if curl is installed
+     if ! [ -x "$(command -v curl)" ]; then
+         echo "curl is not installed. Installing..."
+         apt-get update --yes --quiet
+         apt-get install --yes --quiet curl
+     fi
+     # Download the model file
+     curl -L -o $MODEL $MODEL_DOWNLOAD_URL
+     if [ $? -ne 0 ]; then
+         echo "Download failed. Trying with TLS 1.2..."
+         curl -L --tlsv1.2 -o $MODEL $MODEL_DOWNLOAD_URL
+     fi
+ else
+     echo "$MODEL model found."
+ fi
+
+# Build the project
+make build
+
+# Get the number of available CPU threads
+n_threads=$(grep -c ^processor /proc/cpuinfo)
+
+# Define context window
+n_ctx=4096
+
+# Offload layers to GPU
+n_gpu_layers=10
+
+# Define batch size based on total RAM
+total_ram=$(cat /proc/meminfo | grep MemTotal | awk '{print $2}')
+n_batch=2096
+if [ $total_ram -lt 8000000 ]; then
+    n_batch=1024
+fi
+
+# Display configuration information
+echo "Initializing server with:"
+echo "Batch size: $n_batch"
+echo "Number of CPU threads: $n_threads"
+echo "Number of GPU layers: $n_gpu_layers"
+echo "Context window: $n_ctx"
+
+# Run the server
+exec python3 -m llama_cpp.server --n_ctx $n_ctx --n_threads $n_threads --n_gpu_layers $n_gpu_layers --n_batch $n_batch

--- a/docker-compose-cuda-ggml.yml
+++ b/docker-compose-cuda-ggml.yml
@@ -1,0 +1,46 @@
+version: '3.6'
+
+services:
+  llama-gpt-api-cuda-ggml:
+    build:
+      context: ./cuda
+      dockerfile: ggml.Dockerfile
+    restart: on-failure
+    volumes:
+      - './models:/models'
+      - './cuda:/cuda'
+    ports:
+      - 3001:8000
+    environment:
+      MODEL: '/models/${MODEL_NAME:-llama-2-7b-chat.bin}'
+      MODEL_DOWNLOAD_URL: '${MODEL_DOWNLOAD_URL:-https://huggingface.co/TheBloke/Nous-Hermes-Llama-2-7B-GGML/resolve/main/nous-hermes-llama-2-7b.ggmlv3.q4_0.bin}'
+      N_GQA: '${N_GQA:-1}'
+      USE_MLOCK: 1
+    cap_add:
+      - IPC_LOCK
+      - SYS_RESOURCE
+    command: '/bin/sh /cuda/run.sh'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+  llama-gpt-ui:
+    # TODO: Use this image instead of building from source after the next release
+    # image: 'ghcr.io/getumbrel/llama-gpt-ui:latest'
+    build:
+      context: ./ui
+      dockerfile: Dockerfile
+    ports:
+      - 3000:3000
+    restart: on-failure
+    environment:
+      - 'OPENAI_API_KEY=sk-XXXXXXXXXXXXXXXXXXXX'
+      - 'OPENAI_API_HOST=http://llama-gpt-api-cuda-ggml:8000'
+      - 'DEFAULT_MODEL=/models/${MODEL_NAME:-llama-2-7b-chat.bin}'
+      - 'NEXT_PUBLIC_DEFAULT_SYSTEM_PROMPT=${DEFAULT_SYSTEM_PROMPT:-"You are a helpful and friendly AI assistant. Respond very concisely."}'
+      - 'WAIT_HOSTS=llama-gpt-api-cuda-ggml:8000'
+      - 'WAIT_TIMEOUT=${WAIT_TIMEOUT:-3600}'

--- a/docker-compose-cuda-gguf.yml
+++ b/docker-compose-cuda-gguf.yml
@@ -1,0 +1,46 @@
+version: '3.6'
+
+services:
+  llama-gpt-api-cuda-gguf:
+    build:
+      context: ./cuda
+      dockerfile: gguf.Dockerfile
+    restart: on-failure
+    volumes:
+      - './models:/models'
+      - './cuda:/cuda'
+    ports:
+      - 3001:8000
+    environment:
+      MODEL: '/models/${MODEL_NAME:-code-llama-2-7b-chat.gguf}'
+      MODEL_DOWNLOAD_URL: '${MODEL_DOWNLOAD_URL:-https://huggingface.co/TheBloke/CodeLlama-7B-Instruct-GGUF/resolve/main/codellama-7b-instruct.Q4_K_M.gguf}'
+      N_GQA: '${N_GQA:-1}'
+      USE_MLOCK: 1
+    cap_add:
+      - IPC_LOCK
+      - SYS_RESOURCE
+    command: '/bin/sh /cuda/run.sh'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+
+  llama-gpt-ui:
+    # TODO: Use this image instead of building from source after the next release
+    # image: 'ghcr.io/getumbrel/llama-gpt-ui:latest'
+    build:
+      context: ./ui
+      dockerfile: Dockerfile
+    ports:
+      - 3000:3000
+    restart: on-failure
+    environment:
+      - 'OPENAI_API_KEY=sk-XXXXXXXXXXXXXXXXXXXX'
+      - 'OPENAI_API_HOST=http://llama-gpt-api-cuda-gguf:8000'
+      - 'DEFAULT_MODEL=/models/${MODEL_NAME:-code-llama-2-7b-chat.gguf}'
+      - 'NEXT_PUBLIC_DEFAULT_SYSTEM_PROMPT=${DEFAULT_SYSTEM_PROMPT:-"You are a helpful and friendly AI assistant. Respond very concisely."}'
+      - 'WAIT_HOSTS=llama-gpt-api-cuda-gguf:8000'
+      - 'WAIT_TIMEOUT=${WAIT_TIMEOUT:-3600}'

--- a/run.sh
+++ b/run.sh
@@ -7,10 +7,12 @@ then
     exit
 fi
 
-# Parse command line arguments for model value
+# Parse command line arguments for model value and check for --with-cuda flag
+with_cuda=0
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --model) model="$2"; shift ;;
+        --with-cuda) with_cuda=1 ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -87,9 +89,19 @@ esac
 
 # Run docker compose with docker-compose-ggml.yml or docker-compose-gguf.yml
 
-if [ "$model_type" = "ggml" ]
+if [ "$with_cuda" -eq 1 ]
 then
-    docker-compose -f docker-compose.yml up --build
+    if [ "$model_type" = "ggml" ]
+    then
+        docker compose -f docker-compose-cuda-ggml.yml up --build
+    else
+        docker compose -f docker-compose-cuda-gguf.yml up --build
+    fi
 else
-    docker-compose -f docker-compose-gguf.yml up --build
+    if [ "$model_type" = "ggml" ]
+    then
+        docker compose -f docker-compose.yml up --build
+    else
+        docker compose -f docker-compose-gguf.yml up --build
+    fi
 fi


### PR DESCRIPTION
This PR adds CUDA support to the project. It introduces new Dockerfiles, docker-compose files, and a modified run.sh script to enable GPU acceleration.

#### Changes:
- Added `cuda/ggml.Dockerfile` and `cuda/gguf.Dockerfile` to build CUDA-enabled versions of the GGML and GGUF llama-cpp-python.
- Added `docker-compose-cuda-ggml.yml` and `docker-compose-cuda-gguf.yml` to run CUDA-enabled GGML and GGUF models.
- Created a new `cuda/run.sh` script to handle downloading the model file, setting up the environment, and running the server with GPU offloading.
- Modified `run.sh` to support the `--with-cuda` flag, which runs the CUDA-enabled version of the selected model.

To run the CUDA-enabled version of the model, use the `--with-cuda` flag when executing the `run.sh` script, eg.

```
./run.sh --model 13b --with-cuda
```

Closes #6 
Replaces #11