### PR TITLE
Fix source function in the macOS install script

### DIFF
--- a/run-mac.sh
+++ b/run-mac.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 set -e
 
-# Define a function to refresh the source of .zshrc or .bashrc
+# Define a function to refresh the source of .zshrc, .bashrc, or .bash_profile
 source_shell_rc() {
-    # Source .zshrc or .bashrc
-    if [ -f ~/.zshrc ]; then
-        source ~/.zshrc
-    elif [ -f ~/.bashrc ]; then
-        source ~/.bashrc
-    else
-        echo "No .bashrc or .zshrc file found."
-    fi
+    [ -f ~/.zshrc ] && source ~/.zshrc || {
+        [ -f ~/.bashrc ] && source ~/.bashrc
+        [ -f ~/.bash_profile ] && source ~/.bash_profile
+
+        if [ ! -f ~/.bashrc ] && [ ! -f ~/.bash_profile ]; then
+            echo "No .zshrc, .bashrc, or .bash_profile file found."
+        fi
+    }
 }
 
 # Define a function to install conda with Miniforge3


### PR DESCRIPTION
The conda initialization code produced by `conda init` was placed in the `~/.bash_profile` instead of `~/.bashrc` file and caused the installation to crash. Making sure that `~/.bash_profile` gets sourced as well if it exists fixes that problem.