### PR TITLE
patch shebang to support more platforms

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if docker compose is installed
 if ! command -v docker &> /dev/null


### PR DESCRIPTION
/bin/bash doesn't exist on the linux distribution nixos, a common
pattern to find the interpreter is to rely on /usr/bin/env in shebang
https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my/77586#77586
