### PR TITLE
	Fixed issue where code-7b and other parameter sets were failing to load. Temp fix please review.

### DIFF
--- a/cuda/gguf.Dockerfile
+++ b/cuda/gguf.Dockerfile
@@ -18,10 +18,10 @@ ENV CUDA_DOCKER_ARCH=all
 ENV LLAMA_CUBLAS=1
 
 # Install depencencies
-RUN python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi uvicorn sse-starlette pydantic-settings
+RUN python3 -m pip install --upgrade pip pytest cmake scikit-build setuptools fastapi uvicorn sse-starlette pydantic-settings starlette-context
 
 # Install llama-cpp-python 0.1.80 which has GGUF support (build with cuda)
-RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install llama-cpp-python==0.1.80
+RUN CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install llama-cpp-python==0.2.7
 
 # Run the server
 CMD python3 -m llama_cpp.server

--- a/docker-compose-gguf.yml
+++ b/docker-compose-gguf.yml
@@ -3,7 +3,7 @@ version: '3.6'
 services:
   llama-gpt-api:
     # Pin to llama-cpp-python 0.1.80 with GGUF support
-    image: ghcr.io/abetlen/llama-cpp-python:latest@sha256:de0fd227f348b5e43d4b5b7300f1344e712c14132914d1332182e9ecfde502b2
+    image: ghcr.io/abetlen/llama-cpp-python:0.2.7
     restart: on-failure
     volumes:
       - './models:/models'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.6'
 services:
   llama-gpt-api:
     # Pin the image to llama-cpp-python 0.1.78 to avoid ggml => gguf breaking changes
-    image: ghcr.io/abetlen/llama-cpp-python:latest@sha256:b6d21ff8c4d9baad65e1fa741a0f8c898d68735fff3f3cd777e3f0c6a1839dd4
+    image: ghcr.io/abetlen/llama-cpp-python:0.2.7
     restart: on-failure
     volumes:
       - './models:/models'


### PR DESCRIPTION
	These have been modified to use a version of python cpp that runs faster and seems to work without issues on code-7b and others. I have also made a change noted in the following issues thread which fixes those parameter packages from failing.
	I don't expect this to get merged since it does not include sha security in the compose files. I am only asking for a review from the maintainers to fix this at some point. Thank you all for this project.
	[https://github.com/getumbrel/llama-gpt/issues/98](url)
	
	modified:   docker-compose-gguf.yml
	modified:   docker-compose.yml