### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -93,15 +93,15 @@ if [ "$with_cuda" -eq 1 ]
 then
     if [ "$model_type" = "ggml" ]
     then
-        docker compose -f docker-compose-cuda-ggml.yml up --build
+        docker-compose -f docker-compose-cuda-ggml.yml up --build
     else
-        docker compose -f docker-compose-cuda-gguf.yml up --build
+        docker-compose -f docker-compose-cuda-gguf.yml up --build
     fi
 else
     if [ "$model_type" = "ggml" ]
     then
-        docker compose -f docker-compose.yml up --build
+        docker-compose -f docker-compose.yml up --build
     else
-        docker compose -f docker-compose-gguf.yml up --build
+        docker-compose -f docker-compose-gguf.yml up --build
     fi
 fi


### PR DESCRIPTION
The issue: original used `docker compose` instead of `docker-compose`, which lead to issues (`docker compose` does NOT support -f flag.)

other details:

BEFORE:

```log
❯ sudo ./run.sh --model 7b --with-cuda
unknown shorthand flag: 'f' in -f
See 'docker --help'.

Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

Common Commands:
  run         Create and run a new container from an image
  exec        Execute a command in a running container
  ps          List containers
  ...
```

then i analyzed how `run.sh` was made, and added the change

AFTER:

```
❯ sudo ./run.sh --model 7b --with-cuda
WARN[0000] /home/<hidden>/projects/llamagpt/llama-gpt/docker-compose-cuda-ggml.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Building 30.2s (4/28)
...
```
(i just made an install so it started compiling)
