### PR TITLE
Remove erroneous make command from cuda run.sh

### DIFF
--- a/cuda/run.sh
+++ b/cuda/run.sh
@@ -33,9 +33,6 @@
      echo "$MODEL model found."
  fi
 
-# Build the project
-make build
-
 # Get the number of available CPU threads
 n_threads=$(grep -c ^processor /proc/cpuinfo)
 


### PR DESCRIPTION
See #129 the included make command is not needed for this project. I don't know why it was there in the first place because all the build work is done in the dockerfiles. 